### PR TITLE
Copy to proper directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 
 ### Fixed
--
+- Web application files are copied to proper target, not the current working directory
 
 ### Security
 -

--- a/cls/pkg/isc/ipm/js/base/processor.cls
+++ b/cls/pkg/isc/ipm/js/base/processor.cls
@@ -29,7 +29,11 @@ Method OnBeforePhase(pPhase As %String, ByRef pParams) As %Status
 		} ElseIf (pPhase = "Activate") {
 			// Move files to the right place.
 			Set sourceDir = ##class(%Library.File).NormalizeDirectory(..GetSourceDirectory())
-			Set targetDir = $System.CSP.GetFileName(..GetTargetDirectory())
+			Set targetDir = ..GetTargetDirectory()
+			If (targetDir = "") {
+				// Should never happen, but good to be safe (and avoid using working directory)
+				$$$ThrowStatus($$$ERROR($$$GeneralError,"Target directory not specified."))
+			}
 			Set testFile = sourceDir_"index.html"
 			If '##class(%Library.File).Exists(testFile) {
 				$$$ThrowStatus($$$ERROR($$$GeneralError,$$$FormatText("File '%1' does not exist; will not activate %2 UI changes.",testFile,..#FLAVOR)))
@@ -412,4 +416,3 @@ ClassMethod SanitizeWebAppBase(base As %String) As %String
 }
 
 }
-


### PR DESCRIPTION
Files were going into working directory because GetTargetDirectory() also calls $System.CSP.GetFileName (in all cases).