### PR TITLE
Added kebab-case for Angular 14+ compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2024-02-06
+### Fixed
+- Added support for Angular 14+ by changing cli options to kebab-case
+
 ## [1.1.2] - 2023-02-17
 ### Fixed
 - Web application file copy handles package manager operation ordering more robustly (#4)

--- a/cls/pkg/isc/ipm/js/angular/processor.cls
+++ b/cls/pkg/isc/ipm/js/angular/processor.cls
@@ -55,7 +55,7 @@ Method GetBuildCommand(buildDirectory As %String, Output command)
 {
 	Do ##super(buildDirectory,.command)
 	Set command($i(command)) = "--"
-	Set command($i(command)) = "--baseHref="_..baseHref
+	Set command($i(command)) = "--base-href="_..baseHref
 	Set command($i(command)) = "--progress=false"
 }
 

--- a/module.xml
+++ b/module.xml
@@ -2,7 +2,7 @@
 <Export generator="Cache" version="25">
 <Document name="isc.ipm.js.ZPM"><Module>
   <Name>isc.ipm.js</Name>
-  <Version>1.1.2</Version>
+  <Version>1.1.3</Version>
   <Dependencies>
     <ModuleReference>
       <Name>isc.json</Name>


### PR DESCRIPTION
Changed "baseHref" to "base-href" so that command will be compatible with future versions of Angular