### PR TITLE
fix: allow isc.json 3.x too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.5] - 2025-06-11
+### Fixed
+- Future-proof for isc.json 3.x compatibility (^2.0.1 || ^3.0.0)
 
 ## [1.1.4] - 2025-01-23
 ### Fixed

--- a/module.xml
+++ b/module.xml
@@ -2,11 +2,11 @@
 <Export generator="Cache" version="25">
 <Document name="isc.ipm.js.ZPM"><Module>
   <Name>isc.ipm.js</Name>
-  <Version>1.1.4</Version>
+  <Version>1.1.5</Version>
   <Dependencies>
     <ModuleReference>
       <Name>isc.json</Name>
-      <Version>^2.0.1</Version>
+      <Version>^2.0.1 || ^3.0.0</Version>
     </ModuleReference>
   </Dependencies>
   <Packaging>module</Packaging>


### PR DESCRIPTION
Futureproofs for isc.json versions not yet available on the open exchange.